### PR TITLE
Create only one instance of api

### DIFF
--- a/components/Web3.tsx
+++ b/components/Web3.tsx
@@ -6,7 +6,6 @@ import {
 } from "@polkadot/extension-dapp";
 import { getSpecTypes } from "@polkadot/types-known";
 import { defaults as addressDefaults } from "@polkadot/util-crypto/address/defaults";
-import { TypeRegistry } from "@polkadot/types";
 import { Api as ApiPromise } from "@cennznet/api";
 import Link from "next/link";
 import { hexToString } from "@polkadot/util";
@@ -15,7 +14,6 @@ import Web3Context from "./Web3Context";
 
 import { cennznetExtensions } from "../utils/cennznetExtensions";
 
-const registry = new TypeRegistry();
 const endpoint = process.env.NEXT_PUBLIC_CENNZ_API_ENDPOINT;
 
 async function extractMeta(api) {
@@ -154,18 +152,21 @@ const Web3: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
       setHasWeb3Injected(false);
     }
   };
-  const apiInstance = new ApiPromise({ provider: endpoint, registry });
 
   React.useEffect(() => {
-    if (!apiInstance.isReady) return;
-    setAPI(apiInstance);
+    if (!api) {
+      const apiInstance = new ApiPromise({ provider: endpoint });
+
+      if (!apiInstance.isReady) return;
+      setAPI(apiInstance);
+    }
 
     return () => {
       if (accountsUnsubscribe) {
         accountsUnsubscribe();
       }
     };
-  }, [apiInstance]);
+  });
 
   return (
     <Web3Context.Provider

--- a/components/Web3.tsx
+++ b/components/Web3.tsx
@@ -1,14 +1,18 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {
   web3Enable,
   web3AccountsSubscribe,
   web3FromSource,
+  web3Accounts,
 } from "@polkadot/extension-dapp";
+import { InjectedExtension } from "@polkadot/extension-inject/types";
+
 import { getSpecTypes } from "@polkadot/types-known";
 import { defaults as addressDefaults } from "@polkadot/util-crypto/address/defaults";
 import { Api as ApiPromise } from "@cennznet/api";
 import Link from "next/link";
 import { hexToString } from "@polkadot/util";
+import store from "store";
 
 import Web3Context from "./Web3Context";
 
@@ -52,8 +56,8 @@ async function extractMeta(api) {
 
 const Web3: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
   const [hasWeb3injected, setHasWeb3Injected] = React.useState(false);
-  const [extension, setExtension] = React.useState(null);
-  const [accountsUnsubscribe, setAccountsUnsubsribe] = React.useState(null);
+  const [wallet, setWallet] = React.useState<InjectedExtension>();
+  const [web3Account, setWeb3Account] = React.useState(null);
   const [account, setAccount] = React.useState(null);
   const [showNoExtensionMessage, setShowNoExtensionMessage] =
     React.useState(false);
@@ -63,6 +67,7 @@ const Web3: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
   const [api, setAPI] = React.useState(null);
 
   const getAccountAssets = async (address: string) => {
+    await api.isReady;
     const assets = await api.rpc.genericAsset.registeredAssets();
     const tokenMap = {};
     assets.forEach((asset) => {
@@ -78,7 +83,6 @@ const Web3: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
         return [tokenId, address];
       }
     );
-
     await api.query.genericAsset.freeBalance.multi(
       balanceSubscriptionArg,
       (balances) => {
@@ -101,50 +105,27 @@ const Web3: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
 
   const connectWallet = async (callback) => {
     console.log("connect wallet clicked");
-    if (accountsUnsubscribe) {
-      accountsUnsubscribe();
-    }
     try {
       const extensions = await web3Enable("Litho");
       if (extensions.length === 0) {
         throw new Error("No extension found");
       }
-
-      const polkadotExtension = extensions.find(
-        (ext) => ext.name === "cennznet-extension"
+      const cennznetWallet = extensions.find(
+        (extension) => extension.name === "cennznet-extension"
       );
-      const metadata = polkadotExtension.metadata;
+
+      if (!cennznetWallet) throw new Error("CENNZnet wallet not found");
+      const metadata = cennznetWallet.metadata;
       const checkIfMetaUpdated = localStorage.getItem(`EXTENSION_META_UPDATED`);
       if (!checkIfMetaUpdated && api) {
         const metadataDef = await extractMeta(api);
         await metadata.provide(metadataDef as any);
         localStorage.setItem(`EXTENSION_META_UPDATED`, "true");
       }
-      let unsubscribe = await web3AccountsSubscribe(
-        async (injectedAccounts) => {
-          if (injectedAccounts.length === 0) {
-            setAccount(null);
-            setShowZeroAccountMessage(true);
-          } else {
-            api &&
-              api.isReady.then(async () => {
-                await getAccountAssets(injectedAccounts[0].address);
-              });
-            const injector = await web3FromSource(
-              injectedAccounts[0].meta.source
-            );
-            let payload = { signer: injector.signer };
-            let signer = injectedAccounts[0].address;
-            setAccount({ ...injectedAccounts[0], payload, signer });
-            setShowZeroAccountMessage(false);
-          }
-        }
-      );
 
-      // to unsubscribe on component unmount
-      setAccountsUnsubsribe(unsubscribe);
+      setWallet(cennznetWallet);
+      store.set("CENNZNET-EXTENSION", cennznetWallet);
 
-      setExtension(polkadotExtension);
       setHasWeb3Injected(true);
 
       if (callback) {
@@ -156,19 +137,58 @@ const Web3: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
     }
   };
 
-  React.useEffect(() => {
-    if (!api) {
-      const apiInstance = new ApiPromise({ provider: endpoint });
+  // Create api instance on endpoint change
+  useEffect(() => {
+    const apiInstance = new ApiPromise({ provider: endpoint });
 
-      if (!apiInstance.isReady) return;
-      setAPI(apiInstance);
+    if (!apiInstance.isReady) return;
+    setAPI(apiInstance);
+  }, [endpoint]);
+
+  // Get balances for extension account when api or web3Account has changed
+  useEffect(() => {
+    if (api && web3Account) {
+      getAccountAssets(web3Account.address);
     }
+  }, [api, web3Account]);
 
-    return () => {
-      if (accountsUnsubscribe) {
-        accountsUnsubscribe();
+  // Set account/signer when wallet has changed
+  useEffect(() => {
+    const getSelectedAccount = async () => {
+      await web3Enable("Litho");
+      const accounts = await web3Accounts();
+
+      if (accounts.length === 0) {
+        setWeb3Account(null);
+        setShowZeroAccountMessage(true);
+        throw new Error("No accounts found in CENNZnet wallet");
       }
+      setWeb3Account(accounts[0]);
+
+      const injector = await web3FromSource(accounts[0].meta.source);
+      const payload = { signer: injector.signer };
+      const signer = accounts[0].address;
+      setAccount({ ...accounts[0], payload, signer });
+      setShowZeroAccountMessage(false);
+
+      web3AccountsSubscribe(async (accounts) => {
+        if (accounts.length) {
+          setWeb3Account(accounts[0]);
+        }
+      });
     };
+
+    // if wallet exist,
+    if (wallet) {
+      getSelectedAccount();
+    }
+  }, [wallet]);
+
+  // on mount if wallet is not set, check store and load the wallet
+  useEffect(() => {
+    if (!wallet) {
+      setWallet(store.get("CENNZNET-EXTENSION"));
+    }
   });
 
   return (
@@ -176,7 +196,7 @@ const Web3: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
       value={{
         hasWeb3injected,
         connectWallet,
-        extension,
+        extension: wallet,
         account,
         api,
       }}

--- a/components/Web3.tsx
+++ b/components/Web3.tsx
@@ -115,7 +115,7 @@ const Web3: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
       );
       const metadata = polkadotExtension.metadata;
       const checkIfMetaUpdated = localStorage.getItem(`EXTENSION_META_UPDATED`);
-      if (!checkIfMetaUpdated) {
+      if (!checkIfMetaUpdated && api) {
         const metadataDef = await extractMeta(api);
         await metadata.provide(metadataDef as any);
         localStorage.setItem(`EXTENSION_META_UPDATED`, "true");
@@ -126,7 +126,10 @@ const Web3: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
             setAccount(null);
             setShowZeroAccountMessage(true);
           } else {
-            getAccountAssets(injectedAccounts[0].address);
+            api &&
+              api.isReady.then(async () => {
+                await getAccountAssets(injectedAccounts[0].address);
+              });
             const injector = await web3FromSource(
               injectedAccounts[0].meta.source
             );

--- a/components/nft/NFTDataWrapper.tsx
+++ b/components/nft/NFTDataWrapper.tsx
@@ -62,7 +62,7 @@ const NFTDataWrapper: React.FC<{
         setMetadataUrl(
           gatewayTools.convertToDesiredGateway(
             nft.metadata,
-            "https://gateway.pinata.cloud"
+            "https://ik.imagekit.io/i4ryln6htzn"
           )
         );
       } else {

--- a/components/wallet/ConnectedWalletModal.tsx
+++ b/components/wallet/ConnectedWalletModal.tsx
@@ -48,26 +48,28 @@ const ConnectedWalletModal: React.FC<Props> = ({
       </Text>
       <div className="h-0.5 w-full my-6 bg-litho-black bg-opacity-10" />
       <Text variant="subtitle1">Balance</Text>
-      {Object.keys(web3Context.account.balances).map((symbol) => {
-        return (
-          <div className="mt-4 mb-6" key={symbol}>
-            <div className="flex items-center">
-              <div className="h-12 w-12 bg-gray-200 mr-4 flex items-center justify-center">
-                <img
-                  src={tokenLogoURLs[symbol] || "/cennznet-logo.svg"}
-                  alt="CENNZ balance"
-                  className="h-6 w-6 object-contain"
-                />
+      {web3Context.account.balances
+        ? Object.keys(web3Context.account.balances).map((symbol) => {
+            return (
+              <div className="mt-4 mb-6" key={symbol}>
+                <div className="flex items-center">
+                  <div className="h-12 w-12 bg-gray-200 mr-4 flex items-center justify-center">
+                    <img
+                      src={tokenLogoURLs[symbol] || "/cennznet-logo.svg"}
+                      alt="CENNZ balance"
+                      className="h-6 w-6 object-contain"
+                    />
+                  </div>
+                  <Text variant="subtitle1">
+                    {web3Context.account.balances[symbol].balance}
+                  </Text>
+                  &nbsp;
+                  <Text variant="body1">{symbol}</Text>
+                </div>
               </div>
-              <Text variant="subtitle1">
-                {web3Context.account.balances[symbol].balance}
-              </Text>
-              &nbsp;
-              <Text variant="body1">{symbol}</Text>
-            </div>
-          </div>
-        );
-      })}
+            );
+          })
+        : ""}
       <Link href="https://cennzx.io/">
         <a
           className="flex items-center justify-center bg-litho-blue w-full py-3 h-12"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^17.0.2",
     "react-intersection-observer": "^8.32.1",
     "sass": "^1.32.8",
+    "store": "^2.0.12",
     "swr": "^1.0.0"
   },
   "devDependencies": {

--- a/pages/api/getAllNFTs.ts
+++ b/pages/api/getAllNFTs.ts
@@ -6,8 +6,8 @@ import getMetadata from "../../utils/getMetadata";
 const IPFSGatewayTools = require('@pinata/ipfs-gateway-tools/dist/node');
 const gatewayTools = new IPFSGatewayTools();
 
-const registry = new TypeRegistry();
 const endpoint = process.env.NEXT_PUBLIC_CENNZ_API_ENDPOINT;
+let api = null;
 
 export default async (req, res) => {
   if(cache.has('nfts')) {
@@ -16,7 +16,11 @@ export default async (req, res) => {
     res.json({ nfts: nftsFromCache, total: Object.keys(nftsFromCache).length, cacheHit: true });
     return;
   }
-  const api = await ApiPromise.create({ provider: endpoint, registry });
+  // Create api instance only if it does not exist
+  if (!api) {
+    api = await ApiPromise.create({provider: endpoint});
+  }
+
   const allListings = await api.query.nft.listings.entries();
   const nfts = [];
   await Promise.all(allListings.map(
@@ -47,7 +51,7 @@ export default async (req, res) => {
             royaltiesSchedule,
           }
         }
-        
+
         const { tokens, ...restDetails } = listingDetails as any;
         await Promise.all((listingDetails as any).tokens.map(async (tokenId) => {
           const tokenInfo = await api.derive.nft.tokenInfo(tokenId);

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -5,7 +5,6 @@ import Text from "../components/Text";
 import Web3Context from "../components/Web3Context";
 import NFT from "../components/nft";
 import NFTRenderer from "../components/nft/NFTRenderer";
-import getMetadata from "../utils/getMetadata";
 
 const Me: React.FC<{}> = () => {
   const web3Context = React.useContext(Web3Context);

--- a/pages/nft/[collectionId]/[seriesId]/[serialNumber].tsx
+++ b/pages/nft/[collectionId]/[seriesId]/[serialNumber].tsx
@@ -105,7 +105,6 @@ const NFTDetail: React.FC<{}> = () => {
         };
 
         const otherAttributes = [];
-
         attributes.forEach(({ Text, Url }) => {
           const attributeString = Text || Url;
           if (attributeString) {
@@ -145,7 +144,7 @@ const NFTDetail: React.FC<{}> = () => {
 
         let imageUrl;
         const image = nft.coverImage || nft.image;
-        const fileExtension = getFileExtension(image);
+        const fileExtension = image ? getFileExtension(image) : undefined;
 
         if (!fileExtension) {
           imageUrl = "/litho-default.jpg";
@@ -432,22 +431,26 @@ const NFTDetail: React.FC<{}> = () => {
                 )}
               </div>
               <div className="p-5 flex items-center justify-around">
-                <Link href={nft.image}>
-                  <a
-                    className="text-litho-blue font-medium text-lg underline"
-                    target="_blank"
-                  >
-                    View on IPFS
-                  </a>
-                </Link>
-                <Link href={nft.metadata}>
-                  <a
-                    className="text-litho-blue font-medium text-lg underline"
-                    target="_blank"
-                  >
-                    IPFS Metadata
-                  </a>
-                </Link>
+                {nft.image && (
+                  <Link href={nft.image}>
+                    <a
+                      className="text-litho-blue font-medium text-lg underline"
+                      target="_blank"
+                    >
+                      View on IPFS
+                    </a>
+                  </Link>
+                )}
+                {nft.metadata && (
+                  <Link href={nft.metadata}>
+                    <a
+                      className="text-litho-blue font-medium text-lg underline"
+                      target="_blank"
+                    >
+                      IPFS Metadata
+                    </a>
+                  </Link>
+                )}
               </div>
             </div>
             <div className="w-1/3">

--- a/yarn.lock
+++ b/yarn.lock
@@ -3943,6 +3943,11 @@ stacktrace-parser@0.1.10:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
+store@^2.0.12:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/store/-/store-2.0.12.tgz#8c534e2a0b831f72b75fc5f1119857c44ef5d593"
+  integrity sha1-jFNOKguDH3K3X8XxEZhXxE711ZM=
+
 stream-browserify@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"


### PR DESCRIPTION
Have based my branch on fusion.
Have updated Web3Context to use just one instance and it works well..
It appears that from market place, call similar http call (http://localhost:3000/api/getAllNFTs) is made via hook useSWR.
Have fixed this pages/api/getAllNFTs.ts to create just one instance.. I could not use the earlier created api from react context (as its not allowed to use one hook in other)... 
But have tested it by repeatedly calling - http://localhost:3000/api/getAllNFTs to see what the api object it has...