### PR TITLE
Fix token owner/creator

### DIFF
--- a/pages/nft/[collectionId]/[seriesId]/[serialNumber].tsx
+++ b/pages/nft/[collectionId]/[seriesId]/[serialNumber].tsx
@@ -96,14 +96,17 @@ const NFTDetail: React.FC<{}> = () => {
           router.query.collectionId,
           router.query.seriesId
         );
+        const owner = await web3Context.api.query.nft.tokenOwner(
+          [router.query.collectionId, router.query.seriesId],
+          router.query.serialNumber
+        );
 
-        const { attributes, owner, tokenId } = tokenInfo;
-
+        const { attributes } = tokenInfo;
         const nft: { [index: string]: any } = {
           collectionId: router.query.collectionId,
           seriesId: router.query.seriesId,
           serialNumber: router.query.serialNumber,
-          owner,
+          owner: owner.toString(),
           copies: seriesIssuance.toJSON(),
         };
         if (attributes) {


### PR DESCRIPTION
Fixes - https://github.com/cennznet/litho/issues/25
derive query to get tokenInfo , is not returning the right owner.... made a call to get tokenOwner
will investigate the api query later... 

````
 return api
      .queryMulti([
        [api.query.nft.tokenOwner, [tokenId.collectionId, tokenId.seriesId], tokenId.serialNumber],
        [api.query.nft.seriesAttributes, [tokenId.collectionId, tokenId.seriesId]],
      ])
      .pipe(
        switchMap(
          ([owner, attributes]): Observable<DeriveTokenInfo> => {
            return of(
              new Object({
                owner: owner.toString(),
                attributes: attributes.toJSON(),
                tokenId: tokenId as EnhancedTokenId,
              }) as DeriveTokenInfo
            );
          }
        )
      );
````