### PR TITLE
Fixes nfts on my profile page

### DIFF
--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -31,7 +31,7 @@ const Me: React.FC<{}> = () => {
                     return new Promise(async (resolve) => {
                       const collectionId = token.collectionId.toString();
                       const seriesId = token.seriesId.toString();
-                      let serialNumber = token.serialNumber.toString();
+                      const serialNumber = token.serialNumber.toString();
                       const tokenInfo =
                         await web3Context.api.derive.nft.tokenInfo({
                           collectionId,
@@ -39,17 +39,20 @@ const Me: React.FC<{}> = () => {
                           serialNumber,
                         });
                       const { owner, attributes } = tokenInfo;
-                      const checkIfSingleIssue =
-                        await web3Context.api.query.nft.isSingleIssue(
-                          collectionId,
-                          seriesId
-                        );
+                      let checkIfSingleIssue = false;
+                      if (serialNumber === "0") {
+                        checkIfSingleIssue =
+                          await web3Context.api.query.nft.isSingleIssue(
+                            collectionId,
+                            seriesId
+                          );
+                      }
                       const nft: { [index: string]: any } = {
                         collectionId,
                         seriesId,
                         serialNumber,
                         owner,
-                        attributes: attributes,
+                        attributes,
                         copies: checkIfSingleIssue ? 1 : 2, // copies here is just to show it in format 1/2 2/2 (in case of series nfts)
                         showOne: true,
                         tokenId: [collectionId, seriesId, serialNumber],

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -26,81 +26,59 @@ const Me: React.FC<{}> = () => {
           await Promise.all(
             tokensInCollections.map(async (tokens) => {
               if (tokens.length > 0) {
-                const tokensInCollection = {};
-                tokens.forEach(async (token) => {
-                  const { collectionId, seriesId } = token;
-                  const seriesLevelKey = `${collectionId}-${seriesId}`;
-                  if (tokensInCollection.hasOwnProperty(seriesLevelKey)) {
-                    tokensInCollection[seriesLevelKey].count += 1;
-                  } else {
-                    tokensInCollection[seriesLevelKey] = {
-                      token,
-                      count: 1,
-                    };
-                  }
-                });
-
                 return Promise.all(
-                  Object.values(tokensInCollection).map(
-                    async ({ token, count }) => {
-                      return new Promise(async (resolve) => {
-                        const collectionId = token.collectionId.toString();
-                        const seriesId = token.seriesId.toString();
-                        let serialNumber = 0;
-                        const tokenInfo =
-                          await web3Context.api.derive.nft.tokenInfo({
-                            collectionId,
-                            seriesId,
-                            serialNumber,
-                          });
-                        const { owner, attributes } = tokenInfo;
-
-                        const nft: { [index: string]: any } = {
+                  tokens.map(async (token) => {
+                    return new Promise(async (resolve) => {
+                      const collectionId = token.collectionId.toString();
+                      const seriesId = token.seriesId.toString();
+                      let serialNumber = token.serialNumber.toString();
+                      const tokenInfo =
+                        await web3Context.api.derive.nft.tokenInfo({
                           collectionId,
                           seriesId,
                           serialNumber,
-                          owner,
-                          attributes: attributes,
-                          copies: count,
-                        };
+                        });
+                      const { owner, attributes } = tokenInfo;
+                      const checkIfSingleIssue =
+                        await web3Context.api.query.nft.isSingleIssue(
+                          collectionId,
+                          seriesId
+                        );
+                      const nft: { [index: string]: any } = {
+                        collectionId,
+                        seriesId,
+                        serialNumber,
+                        owner,
+                        attributes: attributes,
+                        copies: checkIfSingleIssue ? 1 : 2, // copies here is just to show it in format 1/2 2/2 (in case of series nfts)
+                        showOne: true,
+                        tokenId: [collectionId, seriesId, serialNumber],
+                      };
 
-                        if (attributes) {
-                          const metadata = getMetadata(attributes);
-                          if (metadata) {
-                            const metadataAttributes = metadata.split(" ");
-                            const metaAsObject = metadataAttributes.length > 1;
-                            const key = metaAsObject
-                              ? metadataAttributes[0].toLowerCase()
-                              : "metadata";
-                            const value = metaAsObject
-                              ? metadataAttributes[1]
-                              : metadataAttributes[0];
-                            nft[key] = value;
-                          }
+                      if (attributes) {
+                        const metadata = getMetadata(attributes);
+                        if (metadata) {
+                          const metadataAttributes = metadata.split(" ");
+                          const metaAsObject = metadataAttributes.length > 1;
+                          const key = metaAsObject
+                            ? metadataAttributes[0].toLowerCase()
+                            : "metadata";
+                          const value = metaAsObject
+                            ? metadataAttributes[1]
+                            : metadataAttributes[0];
+                          nft[key] = value;
                         }
-                        if (count === 1) {
-                          userNFTs.push(nft);
-                        } else {
-                          for (let i = 0; i < count; i++) {
-                            let obj = {};
-                            const serialNumber = i;
-                            const tokenId = [collectionId, seriesId, i];
-                            const showOne = true;
-                            obj = { ...nft, serialNumber, showOne, tokenId };
-                            userNFTs.push(obj);
-                          }
-                        }
-                        resolve(null);
-                      });
-                    }
-                  )
+                      }
+                      userNFTs.push(nft);
+                      resolve(null);
+                    });
+                  })
                 );
               } else {
                 return Promise.resolve();
               }
             })
           );
-          // console.log('user nfts:', userNFTs);
           setNFTs(userNFTs.filter((nft) => nft.metadata));
           setLoading(false);
         });

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -47,6 +47,8 @@ const Me: React.FC<{}> = () => {
                             seriesId
                           );
                       }
+                      // Copies in collection is used by NFTRenderer to show name of nfts with 4/5, 5/5 sufix in case of series nft
+                      // so for series we set copies as 2 and for unique we keep it 1 (later we can change it to bool)
                       const nft: { [index: string]: any } = {
                         collectionId,
                         seriesId,

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -39,7 +39,7 @@ const Me: React.FC<{}> = () => {
                           serialNumber,
                         });
                       const { owner, attributes } = tokenInfo;
-                      let checkIfSingleIssue = false;
+                      let checkIfSingleIssue = serialNumber === "0";
                       if (serialNumber === "0") {
                         checkIfSingleIssue =
                           await web3Context.api.query.nft.isSingleIssue(


### PR DESCRIPTION
Closes https://github.com/cennznet/litho/issues/71

https://user-images.githubusercontent.com/29415595/137393650-6f26641e-c5fd-41dc-b185-4cbf7d06701c.mov

Have hardcoded the users address to see his NFTs on my profile page...
It resolves the issue

So I bought one of those sick tentacles from the Andy Blood collection, but when I click on the NFT from my collection, it takes me to URL /nft/9/2/0 (which is #1 in the collection, that I don't own). I own number 4/10, which should be URL /nft/9/2/3