### PR TITLE
added scroll bar to balance/profile modal

### DIFF
--- a/components/wallet/ConnectedWalletModal.tsx
+++ b/components/wallet/ConnectedWalletModal.tsx
@@ -32,7 +32,7 @@ const ConnectedWalletModal: React.FC<Props> = ({
     <Modal
       onClose={closeModal}
       styles={{
-        modalBody: "w-3/12 absolute top-20 right-20",
+        modalBody: "w-3/12 absolute top-20 right-20 overflow-y-auto h-3/4",
         modalContainer: "z-30",
       }}
       hideClose


### PR DESCRIPTION
As the generic asset keeps growing, we need to add a scrollbar so that user can still see 'my profile' link... or we need to restrict display of first 3 asset balance on right panel 
<img width="691" alt="Screen Shot 2021-12-14 at 6 55 48 AM" src="https://user-images.githubusercontent.com/29415595/145915644-463972c4-fa28-45d5-b0a7-123e5c20e7ed.png">

Closes https://github.com/cennznet/litho/issues/103