### PR TITLE
Hotfix: Add a quick fix for link that has "." at the end during parsing

### DIFF
--- a/refactor/utils/parseDescriptionForViewStoryLink.ts
+++ b/refactor/utils/parseDescriptionForViewStoryLink.ts
@@ -11,5 +11,9 @@ export default function parseDescriptionForViewStoryLink(
 
 	const [startDescription, endDescription] = description.split(match0);
 
-	return [startDescription, match0.replace(/(\shere)*:\s/, ""), endDescription];
+	return [
+		startDescription,
+		match0.replace(/(\shere)*:\s/, "").replace(/\.$/, ""),
+		endDescription,
+	];
 }


### PR DESCRIPTION
## Description

Add a quick fix for link that has "." at the end during parsing
