### PR TITLE
Hotfix: Unable to sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.0.3] - 2022-04-07
+
+- Hotfix: Fix wallet not being able to sign due to restoring issue
+
 ## [1.0.2] - 2022-04-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,11 @@
 
 ## [1.0.2] - 2022-04-06
 
-### Changed
 - Hotfix: Add workaround to fix parsed link in description that include a "." #148
 - Hotfix: Add a quick fix that convert url from hex to string #150
 - Fix issue where CENNZnet extension is not set when clicking Connect Wallet #154
 
 ## [1.0.1] - 2022-03-31
-
-### Changed
 
 - Bump `@cennznet/api` to `rc.2`
 - Use `api.derive.nft.seriesMetadataUri` to fetch metadata

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cennznet/litho",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/refactor/providers/SupportedWalletProvider.tsx
+++ b/refactor/providers/SupportedWalletProvider.tsx
@@ -106,11 +106,12 @@ export default function SupportedWalletProvider({
 		async function restoreWallet() {
 			const storedWallet = store.get("CENNZNET-EXTENSION");
 			if (!storedWallet) return disconnectWallet();
-			setWallet(storedWallet);
+			const extension = await getInstalledExtension?.();
+			setWallet(extension);
 		}
 
 		restoreWallet();
-	}, [disconnectWallet]);
+	}, [disconnectWallet, getInstalledExtension]);
 
 	// 2. Pick the right account once a `wallet` has been set
 	useEffect(() => {
@@ -166,7 +167,7 @@ export default function SupportedWalletProvider({
 	);
 
 	useEffect(() => {
-		if (!api) return;
+		if (!api || !wallet) return;
 
 		(window as any).extractExtensionMetadata = async () => {
 			const metadata = await extractExtensionMetadata(api);


### PR DESCRIPTION
## Description

## Details

#### Changes

- Hotfix: Fix wallet not being able to sign due to restoring issue
