### PR TITLE
Fix: Bump `@cennznet/api` to `2.1.1-alpha.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "format": "prettier --config .prettierrc.json ./ --write"
   },
   "dependencies": {
-    "@cennznet/api": "^2.1.1-alpha.2",
-    "@cennznet/types": "^2.1.1-alpha.2",
+    "@cennznet/api": "^2.1.1-alpha.4",
+    "@cennznet/types": "^2.1.1-alpha.4",
     "@jahed/bem": "^1.2.12",
     "@metamask/detect-provider": "^1.2.0",
     "@metamask/providers": "^8.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -160,7 +160,7 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
-"@cennznet/api@^2.1.1-alpha.2":
+"@cennznet/api@^2.1.1-alpha.4":
   version "2.1.1-alpha.4"
   resolved "https://registry.yarnpkg.com/@cennznet/api/-/api-2.1.1-alpha.4.tgz#87b1489ec71153083b50e384f470db7d2df7c7e4"
   integrity sha512-eXx9qve/H+/j4hu0tNHxckau+ZHPeRQvevBVnN/eQMi2J6zvQ8WnEi0fDgcZQfKS8M8DyessLovMaE+QKiGETA==
@@ -179,7 +179,7 @@
     ethers "^5.6.4"
     eventemitter3 "^4.0.0"
 
-"@cennznet/types@^2.1.1-alpha.2", "@cennznet/types@^2.1.1-alpha.4":
+"@cennznet/types@^2.1.1-alpha.4":
   version "2.1.1-alpha.4"
   resolved "https://registry.yarnpkg.com/@cennznet/types/-/types-2.1.1-alpha.4.tgz#f287c7eac3bc52fed04ed909c1a73fe8727c7b9a"
   integrity sha512-2LnOyFW0bRfNQvo0TjOuEDURDAqDOPs48vpmixFP5wxdN6IcL+T/xMf0sUZPq98kuCoviBGzDGJepN9/EW+vNQ==


### PR DESCRIPTION
## Why

Forgot to add this as part of MetaMask support PR

## What is changing

- Bump `@cennznet/api` to `2.1.1-alpha.4` to support new signing method in MetaMask